### PR TITLE
Changes the generated versions naming from 1.0.x to 1.1.x

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,7 +28,7 @@ jobs:
         id: environment_variables
         run: |
           set -x
-          RELEASE_TAG="1.0.${{ github.run_number }}"
+          RELEASE_TAG="1.1.${{ github.run_number }}-$(git rev-parse --short HEAD)"
           PREFIX_NAME="ufscthesisx-light"
           RELEASE_FILE="${PREFIX_NAME}.zip"
           RELEASE_NAME="${RELEASE_TAG}.zip"


### PR DESCRIPTION
Changes the generated versions naming from 1.0.x to 1.1.x to avoid conflicts with existing versions on the future.